### PR TITLE
Various bug fixes on IEC-101 client and server.

### DIFF
--- a/cli-app/build.gradle
+++ b/cli-app/build.gradle
@@ -16,7 +16,8 @@ dependencies {
     implementation project(":")
     
     implementation 'com.fazecast:jSerialComm:[2.0.0,3.0.0)'
-    
+
+    implementation("ch.qos.logback:logback-classic:1.5.18")
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 }

--- a/cli-app/src/main/java/net/sympower/iec60870/app/common/SampleClientEventListener.java
+++ b/cli-app/src/main/java/net/sympower/iec60870/app/common/SampleClientEventListener.java
@@ -10,29 +10,244 @@
 package net.sympower.iec60870.app.common;
 
 import net.sympower.iec60870.common.ASdu;
+import net.sympower.iec60870.common.ASduType;
+import net.sympower.iec60870.common.CauseOfTransmission;
 import net.sympower.iec60870.common.api.IEC60870EventListener;
+import net.sympower.iec60870.common.elements.IeBinaryCounterReading;
+import net.sympower.iec60870.common.elements.IeDoublePointWithQuality;
+import net.sympower.iec60870.common.elements.IeNormalizedValue;
+import net.sympower.iec60870.common.elements.IeQuality;
+import net.sympower.iec60870.common.elements.IeScaledValue;
+import net.sympower.iec60870.common.elements.IeSingleCommand;
+import net.sympower.iec60870.common.elements.IeSinglePointWithQuality;
+import net.sympower.iec60870.common.elements.IeTime56;
+import net.sympower.iec60870.common.elements.InformationElement;
+import net.sympower.iec60870.common.elements.InformationObject;
 
 import java.io.IOException;
-
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class SampleClientEventListener implements IEC60870EventListener {
 
+    private final SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    private volatile boolean commandPending = false;
+    private volatile String lastCommandType = "";
+
     @Override
     public void onConnectionReady() {
-        System.out.println("Data transfer started successfully");
+        System.out.println("\n[Client] ✓ IEC-101 connection established and ready");
+        System.out.println("[Client] ℹ  Automatic polling - responses will arrive continuously");
     }
 
     @Override
     public void onAsduReceived(ASdu asdu) {
-        System.out.println("Received ASDU: " + asdu.toString());
+        String timestamp = timeFormat.format(new Date());
+        System.out.println("\n[" + timestamp + "] Received ASDU:");
+        interpretAsdu(asdu);
+        
+        if (isConfirmationOrTermination(asdu)) {
+            commandPending = false;
+        }
     }
 
     @Override
     public void onConnectionLost(IOException cause) {
         if (cause != null) {
-            System.err.println("Connection lost: " + cause.getMessage());
+            System.err.println("\n[Client] ✗ Connection lost: " + cause.getMessage());
         } else {
-            System.out.println("Connection closed");
+            System.out.println("\n[Client] Connection closed normally");
+        }
+        commandPending = false;
+    }
+    
+    public void onCommandSent(String commandType) {
+        commandPending = true;
+        lastCommandType = commandType;
+        System.out.println("\n[Client] → " + commandType + " sent");
+        System.out.println("[Client] ℹ  Response will arrive automatically via periodic polling");
+    }
+
+    private void interpretAsdu(ASdu asdu) {
+        ASduType type = asdu.getTypeIdentification();
+        CauseOfTransmission cot = asdu.getCauseOfTransmission();
+        
+        System.out.println("  Type: " + type + " (" + getReadableAsduType(type) + ")");
+        System.out.println("  Cause: " + cot + " (" + getReadableCause(cot) + ")");
+        System.out.println("  Common Address: " + asdu.getCommonAddress());
+        
+        switch (type) {
+            case C_IC_NA_1:
+                interpretInterrogationCommand(asdu, cot);
+                break;
+            case C_SC_NA_1:
+                interpretSingleCommand(asdu, cot);
+                break;
+            case C_CS_NA_1:
+                interpretClockSync(asdu, cot);
+                break;
+            case M_SP_NA_1:
+                interpretSinglePointInfo(asdu);
+                break;
+            case M_DP_NA_1:
+                interpretDoublePointInfo(asdu);
+                break;
+            case M_ME_NA_1:
+                interpretNormalizedMeasurement(asdu);
+                break;
+            case M_ME_NB_1:
+                interpretScaledMeasurement(asdu);
+                break;
+            case M_IT_NA_1:
+                interpretCounterReading(asdu);
+                break;
+            default:
+                System.out.println("  ℹ  Raw ASDU: " + asdu);
+                break;
+        }
+    }
+    
+    private void interpretInterrogationCommand(ASdu asdu, CauseOfTransmission cot) {
+        switch (cot) {
+            case ACTIVATION_CON:
+                System.out.println("  ✓ Interrogation confirmed by server");
+                System.out.println("  → Measurements will arrive automatically");
+                break;
+            case ACTIVATION_TERMINATION:
+                System.out.println("  ✓ Interrogation completed");
+                break;
+            default:
+                System.out.println("  ⚠  Unexpected cause for interrogation: " + cot);
+        }
+    }
+    
+    private void interpretSingleCommand(ASdu asdu, CauseOfTransmission cot) {
+        if (asdu.getInformationObjects() != null && asdu.getInformationObjects().length > 0) {
+            InformationObject io = asdu.getInformationObjects()[0];
+            IeSingleCommand cmd = (IeSingleCommand) io.getInformationElements()[0][0];
+            
+            switch (cot) {
+                case ACTIVATION_CON:
+                    System.out.println("  ✓ Single command confirmed - IOA: " + io.getInformationObjectAddress() + 
+                                     ", State: " + (cmd.isCommandStateOn() ? "ON" : "OFF"));
+                    break;
+                case ACTIVATION_TERMINATION:
+                    System.out.println("  ✓ Single command executed - IOA: " + io.getInformationObjectAddress());
+                    break;
+                default:
+                    System.out.println("  ⚠  Unexpected cause for single command: " + cot);
+            }
+        }
+    }
+    
+    private void interpretClockSync(ASdu asdu, CauseOfTransmission cot) {
+        if (asdu.getInformationObjects() != null && asdu.getInformationObjects().length > 0) {
+            InformationObject io = asdu.getInformationObjects()[0];
+            IeTime56 time = (IeTime56) io.getInformationElements()[0][0];
+            
+            switch (cot) {
+                case ACTIVATION_CON:
+                    System.out.println("  ✓ Clock sync confirmed - Server time: " + new Date(time.getTimestamp()));
+                    break;
+                case ACTIVATION_TERMINATION:
+                    System.out.println("  ✓ Clock sync completed");
+                    break;
+                default:
+                    System.out.println("  ⚠  Unexpected cause for clock sync: " + cot);
+            }
+        }
+    }
+    
+    private void interpretSinglePointInfo(ASdu asdu) {
+        System.out.println("  📊 Single Point Information:");
+        for (InformationObject io : asdu.getInformationObjects()) {
+            for (InformationElement[] elements : io.getInformationElements()) {
+                IeSinglePointWithQuality sp = (IeSinglePointWithQuality) elements[0];
+                System.out.println("    IOA " + io.getInformationObjectAddress() + ": " + 
+                                 (sp.isOn() ? "ON" : "OFF") + 
+                                 (sp.isInvalid() ? " (INVALID)" : "") +
+                                 (sp.isBlocked() ? " (BLOCKED)" : ""));
+            }
+        }
+    }
+    
+    private void interpretDoublePointInfo(ASdu asdu) {
+        System.out.println("  📊 Double Point Information:");
+        for (InformationObject io : asdu.getInformationObjects()) {
+            for (InformationElement[] elements : io.getInformationElements()) {
+                IeDoublePointWithQuality dp = (IeDoublePointWithQuality) elements[0];
+                System.out.println("    IOA " + io.getInformationObjectAddress() + ": " + dp.getDoublePointInformation() +
+                                 (dp.isInvalid() ? " (INVALID)" : ""));
+            }
+        }
+    }
+    
+    private void interpretNormalizedMeasurement(ASdu asdu) {
+        System.out.println("  📊 Normalized Measurements:");
+        for (InformationObject io : asdu.getInformationObjects()) {
+            for (InformationElement[] elements : io.getInformationElements()) {
+                IeNormalizedValue value = (IeNormalizedValue) elements[0];
+                IeQuality quality = elements.length > 1 ? (IeQuality) elements[1] : null;
+                System.out.println("    IOA " + io.getInformationObjectAddress() + ": " + 
+                                 String.format("%.3f", value.getNormalizedValue()) +
+                                 (quality != null && quality.isInvalid() ? " (INVALID)" : ""));
+            }
+        }
+    }
+    
+    private void interpretScaledMeasurement(ASdu asdu) {
+        System.out.println("  📊 Scaled Measurements:");
+        for (InformationObject io : asdu.getInformationObjects()) {
+            for (InformationElement[] elements : io.getInformationElements()) {
+                IeScaledValue value = (IeScaledValue) elements[0];
+                IeQuality quality = elements.length > 1 ? (IeQuality) elements[1] : null;
+                System.out.println("    IOA " + io.getInformationObjectAddress() + ": " + 
+                                 value.getUnnormalizedValue() +
+                                 (quality != null && quality.isInvalid() ? " (INVALID)" : ""));
+            }
+        }
+    }
+    
+    private void interpretCounterReading(ASdu asdu) {
+        System.out.println("  📊 Counter Readings:");
+        for (InformationObject io : asdu.getInformationObjects()) {
+            for (InformationElement[] elements : io.getInformationElements()) {
+                IeBinaryCounterReading counter = (IeBinaryCounterReading) elements[0];
+                System.out.println("    IOA " + io.getInformationObjectAddress() + ": " + 
+                                 counter.getCounterReading() + " (seq: " + counter.getSequenceNumber() + ")");
+            }
+        }
+    }
+    
+    private boolean isConfirmationOrTermination(ASdu asdu) {
+        CauseOfTransmission cot = asdu.getCauseOfTransmission();
+        return cot == CauseOfTransmission.ACTIVATION_CON || 
+               cot == CauseOfTransmission.ACTIVATION_TERMINATION;
+    }
+    
+    private String getReadableAsduType(ASduType type) {
+        switch (type) {
+            case C_IC_NA_1: return "Interrogation Command";
+            case C_SC_NA_1: return "Single Command";
+            case C_CS_NA_1: return "Clock Synchronization";
+            case M_SP_NA_1: return "Single Point Information";
+            case M_DP_NA_1: return "Double Point Information";
+            case M_ME_NA_1: return "Normalized Measurement";
+            case M_ME_NB_1: return "Scaled Measurement";
+            case M_IT_NA_1: return "Counter Reading";
+            default: return "Unknown";
+        }
+    }
+    
+    private String getReadableCause(CauseOfTransmission cot) {
+        switch (cot) {
+            case ACTIVATION: return "Activation";
+            case ACTIVATION_CON: return "Activation Confirmation";
+            case ACTIVATION_TERMINATION: return "Activation Termination";
+            case INTERROGATED_BY_STATION: return "Interrogated by Station";
+            case SPONTANEOUS: return "Spontaneous";
+            case REQUEST: return "Request";
+            default: return "Other";
         }
     }
 }

--- a/cli-app/src/main/java/net/sympower/iec60870/app/common/SampleServerEventListener.java
+++ b/cli-app/src/main/java/net/sympower/iec60870/app/common/SampleServerEventListener.java
@@ -12,31 +12,49 @@ package net.sympower.iec60870.app.common;
 import net.sympower.iec60870.common.ASdu;
 import net.sympower.iec60870.common.ASduType;
 import net.sympower.iec60870.common.CauseOfTransmission;
+import net.sympower.iec60870.common.IEC60870Protocol;
 import net.sympower.iec60870.common.api.IEC60870Connection;
 import net.sympower.iec60870.common.api.IEC60870EventListener;
 import net.sympower.iec60870.common.elements.IeBinaryCounterReading;
+import net.sympower.iec60870.common.elements.IeDoubleCommand;
 import net.sympower.iec60870.common.elements.IeNormalizedValue;
 import net.sympower.iec60870.common.elements.IeQuality;
+import net.sympower.iec60870.common.elements.IeQualifierOfSetPointCommand;
 import net.sympower.iec60870.common.elements.IeScaledValue;
 import net.sympower.iec60870.common.elements.IeSingleCommand;
+import net.sympower.iec60870.common.elements.IeSinglePointWithQuality;
 import net.sympower.iec60870.common.elements.IeTime56;
 import net.sympower.iec60870.common.elements.InformationElement;
 import net.sympower.iec60870.common.elements.InformationObject;
+import net.sympower.iec60870.iec101.connection.Iec101ServerConnection;
 
 import java.io.IOException;
 
 public class SampleServerEventListener implements IEC60870EventListener {
 
-    private final IEC60870Connection connection;
+    private static final int SINGLE_POINT_IOA = 1;
+    private static final int SCALED_MEASUREMENT_IOA = 2;
+    private static final int NORMALIZED_MEASUREMENT_IOA = 3;
+    private static final int COUNTER_IOA = 1;
+    
+    private static final int SAMPLE_SCALED_VALUE = 1234;
+    private static final double SAMPLE_NORMALIZED_VALUE = 0.85;
+    private static final double SAMPLE_READ_VALUE = 0.75;
+    private static final int SAMPLE_COUNTER_VALUE = 12345;
+    private static final int SAMPLE_COUNTER_SEQUENCE = 1;
+    
+    private static final int SERVER_ORIGINATOR_ADDRESS = 0;
+
+    private final Iec101ServerConnection iec101Connection;
     private boolean selected = false;
 
     public SampleServerEventListener(IEC60870Connection connection) {
-        this.connection = connection;
+        this.iec101Connection = (Iec101ServerConnection) connection;
     }
 
     @Override
     public void onConnectionReady() {
-        System.out.println("Connection ready for data transfer");
+        System.out.println("[SampleServer] IEC-101 connection ready for data transfer");
     }
 
     @Override
@@ -49,6 +67,9 @@ public class SampleServerEventListener implements IEC60870EventListener {
                 case C_SC_NA_1:
                     handleSingleCommand(asdu);
                     break;
+                case C_DC_NA_1:
+                    handleDoubleCommand(asdu);
+                    break;
                 case C_CS_NA_1:
                     handleClockSync(asdu);
                     break;
@@ -58,84 +79,218 @@ public class SampleServerEventListener implements IEC60870EventListener {
                 case C_RD_NA_1:
                     handleReadCommand(asdu);
                     break;
+                case C_SE_NA_1:
+                    handleSetPointCommand(asdu);
+                    break;
                 default:
-                    System.out.println("Unsupported ASDU type: " + asdu.getTypeIdentification());
+                    System.out.println("[SampleServer] Unsupported ASDU type: " + asdu.getTypeIdentification());
             }
-        } catch (IOException e) {
-            System.err.println("Error handling ASDU: " + e.getMessage());
+        } catch (Exception e) {
+            System.err.println("[SampleServer] Error handling ASDU: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 
     @Override
     public void onConnectionLost(IOException cause) {
         if (cause != null) {
-            System.err.println("Connection lost: " + cause.getMessage());
+            System.err.println("[SampleServer] Connection lost: " + cause.getMessage());
         } else {
-            System.out.println("Connection closed normally");
+            System.out.println("[SampleServer] Connection closed normally");
         }
+        // Reset state on connection loss
+        selected = false;
     }
 
-    private void handleInterrogation(ASdu asdu) throws IOException {
-        System.out.println("Got interrogation command (C_IC_NA_1). Will send scaled measured values.");
+    private void handleInterrogation(ASdu asdu) {
+        System.out.println("[SampleServer] Processing interrogation command (C_IC_NA_1)");
+
+        queueConfirmation(asdu);
         
-        connection.sendConfirmation(asdu);
-        connection.send(new ASdu(
-            ASduType.M_ME_NB_1, true, CauseOfTransmission.INTERROGATED_BY_STATION, false,
-            false, 0, asdu.getCommonAddress(),
-            new InformationObject(1, new InformationElement[][] {
-                                     { new IeScaledValue(-32768), new IeQuality(true, true, true, true, true) },
-                                     { new IeScaledValue(10), new IeQuality(true, true, true, true, true) },
-                                     { new IeScaledValue(-5), new IeQuality(true, true, true, true, true) } })));
+        sendInterrogationSinglePoint(asdu);
+        sendInterrogationScaledMeasurement(asdu);
+        sendInterrogationNormalizedMeasurement(asdu);
         
-        System.out.println("Sent measured values response");
+        queueTermination(asdu);
+    }
+    
+    private void sendInterrogationSinglePoint(ASdu asdu) {
+        ASdu response = buildInterrogationResponse(
+            ASduType.M_SP_NA_1, 
+            SINGLE_POINT_IOA,
+            createSinglePointInfo(true),
+            asdu.getCommonAddress()
+        );
+        iec101Connection.queueClass1Response(response);
+    }
+    
+    private void sendInterrogationScaledMeasurement(ASdu asdu) {
+        ASdu response = buildInterrogationResponse(
+            ASduType.M_ME_NB_1,
+            SCALED_MEASUREMENT_IOA, 
+            createScaledMeasurement(SAMPLE_SCALED_VALUE),
+            asdu.getCommonAddress()
+        );
+        iec101Connection.queueClass1Response(response);
+    }
+    
+    private void sendInterrogationNormalizedMeasurement(ASdu asdu) {
+        ASdu response = buildInterrogationResponse(
+            ASduType.M_ME_NA_1,
+            NORMALIZED_MEASUREMENT_IOA,
+            createNormalizedMeasurement(SAMPLE_NORMALIZED_VALUE),
+            asdu.getCommonAddress()
+        );
+        iec101Connection.queueClass1Response(response);
     }
 
     private void handleSingleCommand(ASdu asdu) throws IOException {
         InformationObject infoObj = asdu.getInformationObjects()[0];
         IeSingleCommand singleCommand = (IeSingleCommand) infoObj.getInformationElements()[0][0];
+        int ioa = infoObj.getInformationObjectAddress();
 
-        if (infoObj.getInformationObjectAddress() == 5000) {
-            if (singleCommand.isSelect()) {
-                System.out.println("Got single command (C_SC_NA_1) with select=true. Select command.");
-                selected = true;
-            } else if (!singleCommand.isSelect() && selected) {
-                System.out.println("Got single command (C_SC_NA_1) with select=false. Execute selected command.");
-                selected = false;
-            } else {
-                System.out.println("Got single command (C_SC_NA_1) with select=false. But no command is selected, no execution.");
-            }
-            
-            connection.sendConfirmation(asdu);
-        }
+        System.out.println("[SampleServer] Processing single command (C_SC_NA_1) for IOA: " + ioa + 
+                          ", State: " + (singleCommand.isCommandStateOn() ? "ON" : "OFF") +
+                          ", Select: " + singleCommand.isSelect());
+
+        handleSelectExecuteCommand(asdu, singleCommand.isSelect());
     }
 
-    private void handleClockSync(ASdu asdu) throws IOException {
+    private void handleDoubleCommand(ASdu asdu) throws IOException {
+        InformationObject infoObj = asdu.getInformationObjects()[0];
+        IeDoubleCommand doubleCommand = (IeDoubleCommand) infoObj.getInformationElements()[0][0];
+        int ioa = infoObj.getInformationObjectAddress();
+
+        System.out.println("[SampleServer] Processing double command (C_DC_NA_1) for IOA: " + ioa + 
+                          ", State: " + doubleCommand.getCommandState() +
+                          ", Select: " + doubleCommand.isSelect());
+
+        handleSelectExecuteCommand(asdu, doubleCommand.isSelect());
+    }
+
+
+    private void handleCounterInterrogation(ASdu asdu) {
+        System.out.println("[SampleServer] Processing counter interrogation command (C_CI_NA_1)");
+
+        queueConfirmation(asdu);
+
+        ASdu response = buildInterrogationResponse(
+            ASduType.M_IT_NA_1,
+            COUNTER_IOA,
+            createCounterReading(SAMPLE_COUNTER_VALUE, SAMPLE_COUNTER_SEQUENCE),
+            asdu.getCommonAddress()
+        );
+        iec101Connection.queueClass1Response(response);
+
+        queueTermination(asdu);
+    }
+
+
+    private void handleClockSync(ASdu asdu) {
         IeTime56 currentTime = new IeTime56(System.currentTimeMillis());
-        System.out.println("Got Clock synchronization command (C_CS_NA_1). Send current time: " + currentTime);
-        connection.synchronizeClocksResponse(asdu.getCommonAddress(), currentTime);
-    }
-    
-    private void handleCounterInterrogation(ASdu asdu) throws IOException {
-        System.out.println("Got counter interrogation command (C_CI_NA_1). Sending sample counter values.");
+        System.out.println("[SampleServer] Processing clock synchronization command (C_CS_NA_1)");
+
+        int originalIoa = asdu.getInformationObjects()[0].getInformationObjectAddress();
+        InformationElement[] timeElements = new InformationElement[] { currentTime };
         
-        connection.sendConfirmation(asdu);
-        connection.send(new ASdu(ASduType.M_IT_NA_1, true, CauseOfTransmission.INTERROGATED_BY_STATION, false,
-                                 false, 0, asdu.getCommonAddress(),
-                                 new InformationObject(200, new InformationElement[][] {
-                                     { new IeBinaryCounterReading(12345, 1) },
-                                     { new IeBinaryCounterReading(67890, 2) } })));
+        ASdu confirmation = buildClockSyncResponse(asdu, timeElements, originalIoa, CauseOfTransmission.ACTIVATION_CON);
+        iec101Connection.queueClass1Response(confirmation);
+
+        ASdu termination = buildClockSyncResponse(asdu, timeElements, originalIoa, CauseOfTransmission.ACTIVATION_TERMINATION);
+        iec101Connection.queueClass1Response(termination);
     }
     
-    private void handleReadCommand(ASdu asdu) throws IOException {
+    private void handleReadCommand(ASdu asdu) {
         InformationObject infoObj = asdu.getInformationObjects()[0];
         int ioa = infoObj.getInformationObjectAddress();
         
-        System.out.println("Got read command (C_RD_NA_1) for IOA: " + ioa);
+        System.out.println("[SampleServer] Processing read command (C_RD_NA_1) for IOA: " + ioa);
         
-        connection.send(new ASdu(ASduType.M_ME_NA_1, false, CauseOfTransmission.REQUEST, false,
-                                 false, 0, asdu.getCommonAddress(),
-                                 new InformationObject(ioa, new InformationElement[][] {
-                                     { new IeNormalizedValue(0.75),
-                                       new IeQuality(false, false, false, false, false) } })));
+        ASdu response = buildMeasurementResponse(
+            ASduType.M_ME_NA_1, 
+            ioa,
+            new InformationElement[] { new IeNormalizedValue(SAMPLE_READ_VALUE), createGoodQuality() },
+            CauseOfTransmission.REQUEST,
+            asdu.getCommonAddress()
+        );
+        iec101Connection.queueClass2Response(response);
+    }
+    
+    private void handleSetPointCommand(ASdu asdu) throws IOException {
+        InformationObject infoObj = asdu.getInformationObjects()[0];
+        int ioa = infoObj.getInformationObjectAddress();
+        
+        IeNormalizedValue normalizedValue = (IeNormalizedValue) infoObj.getInformationElements()[0][0];
+        IeQualifierOfSetPointCommand qualifier = (IeQualifierOfSetPointCommand) infoObj.getInformationElements()[0][1];
+        
+        System.out.println("[SampleServer] Processing set point command (C_SE_NA_1) for IOA: " + ioa + 
+                          ", Value: " + normalizedValue.getNormalizedValue() +
+                          ", Select: " + qualifier.isSelect());
+        
+        handleSelectExecuteCommand(asdu, qualifier.isSelect());
+    }
+    
+    private void handleSelectExecuteCommand(ASdu asdu, boolean isSelect) throws IOException {
+        if (isSelect) {
+            selected = true;
+            queueConfirmation(asdu);
+        } else {
+            selected = false;
+            queueConfirmation(asdu);
+            queueTermination(asdu);
+        }
+    }
+    
+    private void queueConfirmation(ASdu asdu) {
+        iec101Connection.queueClass1Response(IEC60870Protocol.createConfirmation(asdu, asdu.getOriginatorAddress()));
+    }
+    
+    private void queueTermination(ASdu asdu) {
+        iec101Connection.queueClass1Response(IEC60870Protocol.createTermination(asdu, asdu.getOriginatorAddress()));
+    }
+    
+    private IeQuality createGoodQuality() {
+        return new IeQuality(false, false, false, false, false);
+    }
+    
+    private ASdu buildMeasurementResponse(ASduType type, int ioa, InformationElement[] elements,
+                                        CauseOfTransmission cot, int commonAddress) {
+        return new ASdu(type, false, cot, false, false, SERVER_ORIGINATOR_ADDRESS, 
+                       commonAddress, new InformationObject(ioa, new InformationElement[][] { elements }));
+    }
+    
+    private ASdu buildInterrogationResponse(ASduType type, int ioa, InformationElement[] elements, int commonAddress) {
+        return new ASdu(type, true, CauseOfTransmission.INTERROGATED_BY_STATION,
+                       false, false, SERVER_ORIGINATOR_ADDRESS, commonAddress,
+                       new InformationObject(ioa, new InformationElement[][] { elements }));
+    }
+    
+    private InformationElement[] createSinglePointInfo(boolean value) {
+        return new InformationElement[] { new IeSinglePointWithQuality(value, false, false, false, false) };
+    }
+    
+    private InformationElement[] createScaledMeasurement(int value) {
+        return new InformationElement[] { new IeScaledValue(value), createGoodQuality() };
+    }
+    
+    private InformationElement[] createNormalizedMeasurement(double value) {
+        return new InformationElement[] { new IeNormalizedValue(value), createGoodQuality() };
+    }
+    
+    private InformationElement[] createCounterReading(int value, int sequence) {
+        return new InformationElement[] { new IeBinaryCounterReading(value, sequence) };
+    }
+    
+    private ASdu buildClockSyncResponse(ASdu originalAsdu, InformationElement[] timeElements, int ioa, CauseOfTransmission cot) {
+        return new ASdu(
+            ASduType.C_CS_NA_1,
+            originalAsdu.isSequenceOfElements(),
+            cot,
+            originalAsdu.isTestFrame(),
+            false,
+            originalAsdu.getOriginatorAddress(),
+            originalAsdu.getCommonAddress(),
+            new InformationObject[] { new InformationObject(ioa, new InformationElement[][] { timeElements }) }
+        );
     }
 }

--- a/cli-app/src/main/java/net/sympower/iec60870/app/iec101/SampleIEC101Server.java
+++ b/cli-app/src/main/java/net/sympower/iec60870/app/iec101/SampleIEC101Server.java
@@ -11,6 +11,7 @@ package net.sympower.iec60870.app.iec101;
 
 import java.io.IOException;
 
+import com.fazecast.jSerialComm.SerialPort;
 import net.sympower.iec60870.app.common.SampleServerListener;
 import net.sympower.iec60870.iec101.api.Iec101Server;
 import net.sympower.iec60870.iec101.api.Iec101ServerBuilder;
@@ -23,14 +24,15 @@ public class SampleIEC101Server {
     private static final Logger logger = LoggerFactory.getLogger(SampleIEC101Server.class);
 
     public static void main(String[] args) throws IOException {
-        String portName = args.length > 0 ? args[0] : "/dev/ttys006";
+        String portName = args.length > 0 ? args[0] : "/dev/ttys008";
         int baudRate = args.length > 1 ? Integer.parseInt(args[1]) : 9600;
 
         Iec101Server server = new Iec101ServerBuilder(portName)
                 .baudRate(baudRate)
                 .dataBits(8)
                 .stopBits(1)
-                .parity(1) // TODO check this is sensible
+                .linkAddress(2)
+                .parity(SerialPort.EVEN_PARITY)
                 .build();
 
         server.start(new SampleServerListener());

--- a/cli-app/src/main/resources/logback.xml
+++ b/cli-app/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Console appender for sample applications -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="INFO" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
@@ -12,6 +12,6 @@
     
     <!-- Root logger -->
     <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="INFO"/>
     </root>
 </configuration>

--- a/src/main/java/net/sympower/iec60870/common/ASdu.java
+++ b/src/main/java/net/sympower/iec60870/common/ASdu.java
@@ -23,14 +23,12 @@
  */
 package net.sympower.iec60870.common;
 
-import java.io.IOException;
-import java.text.MessageFormat;
-
-import javax.xml.bind.DatatypeConverter;
-
-import net.sympower.iec60870.common.IEC60870Settings;
 import net.sympower.iec60870.common.elements.InformationObject;
 import net.sympower.iec60870.internal.ExtendedDataInputStream;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.text.MessageFormat;
 
 /**
  * The application service data unit (ASDU). The ASDU is the payload of the application protocol data unit (APDU). Its
@@ -179,6 +177,7 @@ public class ASdu {
         }
 
         currentByte = is.readUnsignedByte();
+        
         CauseOfTransmission causeOfTransmission = CauseOfTransmission.causeFor(currentByte & 0x3f);
         boolean test = byteHasMask(currentByte, 0x80);
         boolean negativeConfirm = byteHasMask(currentByte, 0x40);
@@ -197,9 +196,10 @@ public class ASdu {
             commonAddress = is.readUnsignedByte();
         }
         else {
-            commonAddress = is.readUnsignedByte() | (is.readUnsignedByte() << 8);
-
-            aSduLength--;
+            int lowByte = is.readUnsignedByte();
+            int highByte = is.readUnsignedByte();
+            commonAddress = lowByte | (highByte << 8);
+            aSduLength -= 2;
         }
 
         InformationObject[] informationObjects;

--- a/src/main/java/net/sympower/iec60870/common/IEC60870Protocol.java
+++ b/src/main/java/net/sympower/iec60870/common/IEC60870Protocol.java
@@ -593,7 +593,15 @@ public final class IEC60870Protocol {
     public static ASdu createConfirmation(ASdu originalAsdu, int originatorAddress) {
         return new ASdu(originalAsdu.getTypeIdentification(), originalAsdu.isSequenceOfElements(),
                        CauseOfTransmission.ACTIVATION_CON, originalAsdu.isTestFrame(), 
-                       originalAsdu.isNegativeConfirm(), originatorAddress, 
+                       false, // Always positive confirmation for successful activation
+                       originatorAddress, 
+                       originalAsdu.getCommonAddress(), originalAsdu.getInformationObjects());
+    }
+    
+    public static ASdu createTermination(ASdu originalAsdu, int originatorAddress) {
+        return new ASdu(originalAsdu.getTypeIdentification(), originalAsdu.isSequenceOfElements(),
+                       CauseOfTransmission.ACTIVATION_TERMINATION, originalAsdu.isTestFrame(), 
+                       false, originatorAddress, 
                        originalAsdu.getCommonAddress(), originalAsdu.getInformationObjects());
     }
 }

--- a/src/main/java/net/sympower/iec60870/common/IEC60870Settings.java
+++ b/src/main/java/net/sympower/iec60870/common/IEC60870Settings.java
@@ -28,19 +28,23 @@ public class IEC60870Settings {
     private int messageFragmentTimeout;
 
     private int cotFieldLength;
-    private int commonAddressFieldLength; //
+    private int commonAddressFieldLength;
     private int ioaFieldLength;
+    private int linkAddressLength;
 
     private int connectionTimeout;
+    private int interFrameDelayMs;
 
     public IEC60870Settings() {
-        this.messageFragmentTimeout = 300_000; // 5 minutes instead of 5 seconds
+        this.messageFragmentTimeout = 3_000;
 
         this.cotFieldLength = 2;
         this.commonAddressFieldLength = 2;
         this.ioaFieldLength = 3;
+        this.linkAddressLength = 2;
 
-        this.connectionTimeout = 600_000; // 10 minutes instead of 30 seconds
+        this.connectionTimeout = 6_000;
+        this.interFrameDelayMs = 250;
     }
 
     public IEC60870Settings(IEC60870Settings settings) {
@@ -50,8 +54,10 @@ public class IEC60870Settings {
         cotFieldLength = settings.cotFieldLength;
         commonAddressFieldLength = settings.commonAddressFieldLength;
         ioaFieldLength = settings.ioaFieldLength;
+        linkAddressLength = settings.linkAddressLength;
 
         connectionTimeout = settings.connectionTimeout;
+        interFrameDelayMs = settings.interFrameDelayMs;
     }
 
     public int getMessageFragmentTimeout() {
@@ -89,7 +95,28 @@ public class IEC60870Settings {
 
     public void setConnectionTimeout(int time) {
         this.connectionTimeout = time;
+    }
 
+    public int getLinkAddressLength() {
+        return linkAddressLength;
+    }
+
+    public void setLinkAddressLength(int linkAddressLength) {
+        if (linkAddressLength < 1 || linkAddressLength > 2) {
+            throw new IllegalArgumentException("Link address length must be 1 or 2 bytes");
+        }
+        this.linkAddressLength = linkAddressLength;
+    }
+
+    public int getInterFrameDelayMs() {
+        return interFrameDelayMs;
+    }
+
+    public void setInterFrameDelayMs(int interFrameDelayMs) {
+        if (interFrameDelayMs < 0) {
+            throw new IllegalArgumentException("Inter-frame delay must be non-negative");
+        }
+        this.interFrameDelayMs = interFrameDelayMs;
     }
 
 }

--- a/src/main/java/net/sympower/iec60870/common/api/IEC60870Connection.java
+++ b/src/main/java/net/sympower/iec60870/common/api/IEC60870Connection.java
@@ -25,17 +25,10 @@ package net.sympower.iec60870.common.api;
 
 import net.sympower.iec60870.common.ASdu;
 import net.sympower.iec60870.common.CauseOfTransmission;
-import net.sympower.iec60870.common.IEC60870Settings;
 import net.sympower.iec60870.common.IEC60870Protocol;
-import net.sympower.iec60870.common.elements.IeAckFileOrSectionQualifier;
+import net.sympower.iec60870.common.IEC60870Settings;
 import net.sympower.iec60870.common.elements.IeBinaryStateInformation;
-import net.sympower.iec60870.common.elements.IeChecksum;
 import net.sympower.iec60870.common.elements.IeDoubleCommand;
-import net.sympower.iec60870.common.elements.IeFileReadyQualifier;
-import net.sympower.iec60870.common.elements.IeFileSegment;
-import net.sympower.iec60870.common.elements.IeLengthOfFileOrSection;
-import net.sympower.iec60870.common.elements.IeNameOfFile;
-import net.sympower.iec60870.common.elements.IeNameOfSection;
 import net.sympower.iec60870.common.elements.IeNormalizedValue;
 import net.sympower.iec60870.common.elements.IeQualifierOfCounterInterrogation;
 import net.sympower.iec60870.common.elements.IeQualifierOfInterrogation;
@@ -43,16 +36,14 @@ import net.sympower.iec60870.common.elements.IeQualifierOfParameterOfMeasuredVal
 import net.sympower.iec60870.common.elements.IeQualifierOfSetPointCommand;
 import net.sympower.iec60870.common.elements.IeRegulatingStepCommand;
 import net.sympower.iec60870.common.elements.IeScaledValue;
-import net.sympower.iec60870.common.elements.IeSectionReadyQualifier;
 import net.sympower.iec60870.common.elements.IeShortFloat;
 import net.sympower.iec60870.common.elements.IeSingleCommand;
 import net.sympower.iec60870.common.elements.IeTestSequenceCounter;
 import net.sympower.iec60870.common.elements.IeTime56;
-import net.sympower.iec60870.common.elements.InformationElement;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -116,7 +107,11 @@ public abstract class IEC60870Connection {
 
     
     public void sendConfirmation(ASdu asdu) throws IOException {
-        send(IEC60870Protocol.createConfirmation(asdu, originatorAddress));
+        send(IEC60870Protocol.createConfirmation(asdu, asdu.getOriginatorAddress()));
+    }
+    
+    public void sendTermination(ASdu asdu) throws IOException {
+        send(IEC60870Protocol.createTermination(asdu, asdu.getOriginatorAddress()));
     }
 
     protected abstract void performClose() throws IOException;

--- a/src/main/java/net/sympower/iec60870/iec101/connection/Iec101ClientSettings.java
+++ b/src/main/java/net/sympower/iec60870/iec101/connection/Iec101ClientSettings.java
@@ -31,6 +31,7 @@ public class Iec101ClientSettings extends IEC60870Settings {
     private long ackTimeoutMs = 200;
     private long initializationTimeoutMs = 5000;
     private long handshakePollIntervalMs = 1000;
+    private long pollingIntervalMs = 1000;
 
     public Iec101ClientSettings() {
         super();
@@ -67,5 +68,13 @@ public class Iec101ClientSettings extends IEC60870Settings {
 
     public void setHandshakePollIntervalMs(long handshakePollIntervalMs) {
         this.handshakePollIntervalMs = handshakePollIntervalMs;
+    }
+    
+    public long getPollingIntervalMs() {
+        return pollingIntervalMs;
+    }
+    
+    public void setPollingIntervalMs(long pollingIntervalMs) {
+        this.pollingIntervalMs = pollingIntervalMs;
     }
 }

--- a/src/main/java/net/sympower/iec60870/iec101/frame/BitUtils.java
+++ b/src/main/java/net/sympower/iec60870/iec101/frame/BitUtils.java
@@ -145,4 +145,59 @@ public final class BitUtils {
         }
         return result.toString().trim();
     }
+    
+    /**
+     * Reads a multi-byte value from a byte array in little-endian format.
+     * <p>
+     * Reads the specified number of bytes starting at the given offset and combines
+     * them into a single integer value with the least significant byte first.
+     * <p>
+     * Example: readBytes(new byte[]{0x34, 0x12, 0x56}, 0, 2) returns 0x1234
+     * - First byte (0x34) is LSB
+     * - Second byte (0x12) is MSB
+     * - Result: 0x34 | (0x12 << 8) = 0x1234
+     * 
+     * @param buffer the byte array to read from
+     * @param offset the starting position in the buffer
+     * @param byteLength the number of bytes to read (1-4)
+     * @return the multi-byte value as an integer
+     * @throws IllegalArgumentException if byteLength is not between 1 and 4
+     */
+    public static int readBytes(byte[] buffer, int offset, int byteLength) {
+        if (byteLength < 1 || byteLength > 4) {
+            throw new IllegalArgumentException("Byte length must be between 1 and 4");
+        }
+        
+        int value = 0;
+        for (int i = 0; i < byteLength; i++) {
+            value |= (toUnsigned(buffer[offset + i]) << (8 * i)); // LSB first
+        }
+        return value;
+    }
+    
+    /**
+     * Writes a multi-byte value to a byte array in little-endian format.
+     * <p>
+     * Writes the specified number of bytes starting at the given offset, with the
+     * least significant byte first.
+     * <p>
+     * Example: writeBytes(buffer, 0, 0x1234, 2) writes [0x34, 0x12]
+     * - First byte: 0x1234 & 0xFF = 0x34 (LSB)
+     * - Second byte: (0x1234 >> 8) & 0xFF = 0x12 (MSB)
+     * 
+     * @param buffer the byte array to write to
+     * @param offset the starting position in the buffer
+     * @param value the value to write
+     * @param byteLength the number of bytes to write (1-4)
+     * @throws IllegalArgumentException if byteLength is not between 1 and 4
+     */
+    public static void writeBytes(byte[] buffer, int offset, int value, int byteLength) {
+        if (byteLength < 1 || byteLength > 4) {
+            throw new IllegalArgumentException("Byte length must be between 1 and 4");
+        }
+        
+        for (int i = 0; i < byteLength; i++) {
+            buffer[offset + i] = (byte) ((value >> (8 * i)) & 0xFF); // LSB first
+        }
+    }
 }

--- a/src/main/java/net/sympower/iec60870/iec101/frame/Iec101Frame.java
+++ b/src/main/java/net/sympower/iec60870/iec101/frame/Iec101Frame.java
@@ -70,11 +70,11 @@ public abstract class Iec101Frame {
         REQUEST_CLASS_2_DATA(11),
         
         // Secondary station functions (PRM=0)
-        ACK_CONFIRM(0),
         NACK_MESSAGE(1),
         STATUS_LINK_ACCESS_DEMAND(8),
-        STATUS_LINK_NO_DATA(9),
-        USER_DATA_RESPONSE(8),
+        RESP_NACK_NO_DATA(9),
+        STATUS_LINK(11),
+        USER_DATA_RESPONSE(0),
         NACK_NOT_FUNCTIONING(14),
         NACK_NOT_IMPLEMENTED(15);
         
@@ -91,7 +91,7 @@ public abstract class Iec101Frame {
         public static FunctionCode fromCode(int code, boolean prm) {
             switch (code) {
                 case 0:
-                    return prm ? RESET_REMOTE_LINK : ACK_CONFIRM;
+                    return prm ? RESET_REMOTE_LINK : USER_DATA_RESPONSE;
                 case 1:
                     return prm ? RESET_USER_PROCESS : NACK_MESSAGE;
                 case 2:
@@ -108,11 +108,11 @@ public abstract class Iec101Frame {
                     }
                     throw new IllegalArgumentException("Function code 8 not valid for primary station");
                 case 9:
-                    return prm ? REQUEST_LINK_STATUS : STATUS_LINK_NO_DATA;
+                    return prm ? REQUEST_LINK_STATUS : RESP_NACK_NO_DATA;
                 case 10:
                     return REQUEST_CLASS_1_DATA;
                 case 11:
-                    return REQUEST_CLASS_2_DATA;
+                    return prm ? REQUEST_CLASS_2_DATA : STATUS_LINK;
                 case 14:
                     return NACK_NOT_FUNCTIONING;
                 case 15:

--- a/src/test/java/net/sympower/iec60870/iec101/Iec101ClientServerIntegrationTest.java
+++ b/src/test/java/net/sympower/iec60870/iec101/Iec101ClientServerIntegrationTest.java
@@ -27,31 +27,21 @@ import net.sympower.iec60870.common.ASdu;
 import net.sympower.iec60870.common.ASduType;
 import net.sympower.iec60870.common.CauseOfTransmission;
 import net.sympower.iec60870.common.IEC60870Settings;
-import net.sympower.iec60870.common.api.IEC60870EventListener;
-import net.sympower.iec60870.common.elements.IeBinaryCounterReading;
-import net.sympower.iec60870.common.elements.IeBinaryStateInformation;
 import net.sympower.iec60870.common.elements.IeDoubleCommand;
-import net.sympower.iec60870.common.elements.IeFixedTestBitPattern;
 import net.sympower.iec60870.common.elements.IeNormalizedValue;
 import net.sympower.iec60870.common.elements.IeQualifierOfCounterInterrogation;
 import net.sympower.iec60870.common.elements.IeQualifierOfInterrogation;
-import net.sympower.iec60870.common.elements.IeQualifierOfParameterActivation;
-import net.sympower.iec60870.common.elements.IeQualifierOfParameterOfMeasuredValues;
 import net.sympower.iec60870.common.elements.IeQualifierOfSetPointCommand;
-import net.sympower.iec60870.common.elements.IeQuality;
-import net.sympower.iec60870.common.elements.IeRegulatingStepCommand;
 import net.sympower.iec60870.common.elements.IeScaledValue;
 import net.sympower.iec60870.common.elements.IeShortFloat;
 import net.sympower.iec60870.common.elements.IeSingleCommand;
-import net.sympower.iec60870.common.elements.IeTestSequenceCounter;
 import net.sympower.iec60870.common.elements.IeTime56;
-import net.sympower.iec60870.common.elements.InformationElement;
 import net.sympower.iec60870.common.elements.InformationObject;
 import net.sympower.iec60870.iec101.connection.Iec101ClientConnection;
 import net.sympower.iec60870.iec101.connection.Iec101ClientSettings;
 import net.sympower.iec60870.iec101.connection.Iec101ServerConnection;
 import net.sympower.iec60870.spy.AsduRecordingClient;
-import net.sympower.iec60870.spy.RespondingServer;
+import net.sympower.iec60870.spy.Iec101RespondingServer;
 import org.junit.Test;
 
 import java.io.DataInputStream;
@@ -60,334 +50,133 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 
-import static net.sympower.iec60870.iec101.Iec101TestConstants.BITSTRING_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.BITSTRING_VALUE_1;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.COMMON_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.CONNECTION_TIMEOUT_SECONDS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.COUNTER_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.COUNTER_VALUE_1;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.COUNTER_VALUE_2;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.DOUBLE_COMMAND_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.LINK_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.MEASUREMENT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.NORMALIZED_TOLERANCE;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.PARAMETER_ACTIVATION_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.PARAMETER_FLOAT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.PARAMETER_NORMALIZED_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.PARAMETER_SCALED_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.READ_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.REGULATING_STEP_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.SCALED_SET_POINT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.SCALED_VALUE;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.SET_POINT_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.SHORT_FLOAT_ADDRESS;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.SINGLE_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TEST_SEQUENCE_VALUE;
 import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMEOUT_UNIT;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_BITSTRING_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_DOUBLE_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_FLOAT_SETPOINT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_NORMALIZED_SETPOINT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_REGULATING_STEP_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_SCALED_SETPOINT_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIMETAG_SINGLE_COMMAND_ADDRESS;
-import static net.sympower.iec60870.iec101.Iec101TestConstants.TIME_TOLERANCE_MS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class Iec101ClientServerIntegrationTest extends Iec101IntegrationTest {
+
+    private Iec101RespondingServer spyIec101ServerEventListener;
+    private AsduRecordingClient asduRecordingClient;
 
     private PipedOutputStream clientToServerPipe;
     private PipedInputStream serverInput;
     private PipedOutputStream serverToClientPipe;
     private PipedInputStream clientInput;
 
+    
     @Test
-    public void testInterrogationCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testInterrogationCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsInterrogationCommand();
+        thenIec101ServerReceivesCommand(ASduType.C_IC_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_IC_NA_1);
-        thenClientReceivesInterrogationResponse();
+        thenClientReceivesConfirmation(ASduType.C_IC_NA_1, CauseOfTransmission.ACTIVATION_CON);
+        
+        thenClientReceivesSinglePointData();
+        thenClientReceivesDoublePointData();
+        thenClientReceivesMeasurementData();
+        
+        thenClientReceivesTermination(ASduType.C_IC_NA_1, CauseOfTransmission.ACTIVATION_TERMINATION);
     }
 
     @Test
-    public void testSingleCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testSingleCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsSingleCommand(true);
+        thenIec101ServerReceivesCommand(ASduType.C_SC_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_SC_NA_1);
-        thenClientReceivesSingleCommandConfirmation();
+        thenClientReceivesConfirmation(ASduType.C_SC_NA_1, CauseOfTransmission.ACTIVATION_CON);
     }
 
     @Test
-    public void testDoubleCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testDoubleCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsDoubleCommand(IeDoubleCommand.DoubleCommandState.ON);
+        thenIec101ServerReceivesCommand(ASduType.C_DC_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_DC_NA_1);
-        thenClientReceivesDoubleCommandConfirmation();
+        thenClientReceivesConfirmation(ASduType.C_DC_NA_1, CauseOfTransmission.ACTIVATION_CON);
     }
 
     @Test
-    public void testTestCommand() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsTestCommand();
-        
-        thenServerReceivesCommand(ASduType.C_TS_NA_1);
-        thenClientReceivesTestCommandConfirmation();
-    }
-
-    @Test
-    public void testClockSynchronization() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsClockSynchronization();
-        
-        thenServerReceivesCommand(ASduType.C_CS_NA_1);
-        thenClientReceivesClockSyncConfirmation();
-    }
-
-     @Test
-    public void testCounterInterrogation() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testCounterInterrogationWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsCounterInterrogation();
+        thenIec101ServerReceivesCommand(ASduType.C_CI_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_CI_NA_1);
-        thenClientReceivesCounterInterrogationResponse();
+        thenClientReceivesConfirmation(ASduType.C_CI_NA_1, CauseOfTransmission.ACTIVATION_CON);
+        thenClientReceivesCounterData();
+        thenClientReceivesTermination(ASduType.C_CI_NA_1, CauseOfTransmission.ACTIVATION_TERMINATION);
     }
 
     @Test
-    public void testReadCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testClockSynchronizationWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
+        
+        whenClientSendsClockSynchronization();
+        thenIec101ServerReceivesCommand(ASduType.C_CS_NA_1);
+        
+        thenClientReceivesClockSyncResponse();
+    }
+
+    @Test
+    public void testReadCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsReadCommand();
+        thenIec101ServerReceivesCommand(ASduType.C_RD_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_RD_NA_1);
-        thenClientReceivesReadCommandResponse();
+        thenClientReceivesReadResponse();
     }
 
     @Test
-    public void testNormalizedSetPointCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testNormalizedSetPointCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsNormalizedSetPointCommand(0.75f);
+        thenIec101ServerReceivesCommand(ASduType.C_SE_NA_1);
         
-        thenServerReceivesCommand(ASduType.C_SE_NA_1);
-        thenClientReceivesSetPointConfirmation();
+        thenClientReceivesConfirmation(ASduType.C_SE_NA_1, CauseOfTransmission.ACTIVATION_CON);
     }
 
     @Test
-    public void testScaledSetPointCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testScaledSetPointCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsScaledSetPointCommand(100);
+        thenIec101ServerReceivesCommand(ASduType.C_SE_NB_1);
         
-        thenServerReceivesCommand(ASduType.C_SE_NB_1);
-        thenClientReceivesScaledSetPointConfirmation();
+        thenClientReceivesConfirmation(ASduType.C_SE_NB_1, CauseOfTransmission.ACTIVATION_CON);
     }
 
     @Test
-    public void testShortFloatSetPointCommand() throws Exception {
-        givenClientAndServerAreConnected();
+    public void testShortFloatSetPointCommandWithIec101Server() throws Exception {
+        givenClientAndIec101ServerAreConnectedWithFastPolling();
         
         whenClientSendsShortFloatSetPointCommand(3.14f);
+        thenIec101ServerReceivesCommand(ASduType.C_SE_NC_1);
         
-        thenServerReceivesCommand(ASduType.C_SE_NC_1);
-        thenClientReceivesShortFloatSetPointConfirmation();
-    }
-
-    @Test
-    public void testRegulatingStepCommand() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsRegulatingStepCommand(IeRegulatingStepCommand.StepCommandState.NEXT_STEP_HIGHER);
-        
-        thenServerReceivesCommand(ASduType.C_RC_NA_1);
-        thenClientReceivesRegulatingStepConfirmation();
-    }
-
-    @Test
-    public void testParameterActivation() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsParameterActivation();
-        
-        thenServerReceivesCommand(ASduType.P_AC_NA_1);
-        thenClientReceivesParameterActivationConfirmation();
-    }
-
-
-    @Test
-    public void testSingleCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsSingleCommandWithTimeTag(true);
-        
-        thenServerReceivesCommand(ASduType.C_SC_TA_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_SC_TA_1);
-    }
-
-    @Test
-    public void testTestCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsTestCommandWithTimeTag();
-        
-        thenServerReceivesCommand(ASduType.C_TS_TA_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_TS_TA_1);
-    }
-
-    @Test
-    public void testDoubleCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsDoubleCommandWithTimeTag(IeDoubleCommand.DoubleCommandState.ON);
-        
-        thenServerReceivesCommand(ASduType.C_DC_TA_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_DC_TA_1);
-    }
-
-    @Test
-    public void testRegulatingStepCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsRegulatingStepCommandWithTimeTag(IeRegulatingStepCommand.StepCommandState.NEXT_STEP_HIGHER);
-        
-        thenServerReceivesCommand(ASduType.C_RC_TA_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_RC_TA_1);
-    }
-
-    @Test
-    public void testSetNormalizedValueCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsSetNormalizedValueCommandWithTimeTag(0.75f);
-        
-        thenServerReceivesCommand(ASduType.C_SE_TA_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_SE_TA_1);
-    }
-
-    @Test
-    public void testSetScaledValueCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsSetScaledValueCommandWithTimeTag(100);
-        
-        thenServerReceivesCommand(ASduType.C_SE_TB_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_SE_TB_1);
-    }
-
-    @Test
-    public void testSetShortFloatCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsSetShortFloatCommandWithTimeTag(3.14f);
-        
-        thenServerReceivesCommand(ASduType.C_SE_TC_1);
-        thenClientReceivesTimeTaggedCommandConfirmation(ASduType.C_SE_TC_1);
-    }
-
-    @Test
-    public void testParameterNormalizedValue() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsParameterNormalizedValue(0.25f);
-        
-        thenServerReceivesCommand(ASduType.P_ME_NA_1);
-        thenClientReceivesParameterConfirmation(ASduType.P_ME_NA_1);
-    }
-
-    @Test
-    public void testParameterScaledValue() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsParameterScaledValue(500);
-        
-        thenServerReceivesCommand(ASduType.P_ME_NB_1);
-        thenClientReceivesParameterConfirmation(ASduType.P_ME_NB_1);
-    }
-
-    @Test
-    public void testParameterShortFloat() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsParameterShortFloat(1.414f);
-        
-        thenServerReceivesCommand(ASduType.P_ME_NC_1);
-        thenClientReceivesParameterConfirmation(ASduType.P_ME_NC_1);
-    }
-
-    @Test
-    public void testBitstringCommand() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsBitstringCommand();
-        
-        thenServerReceivesCommand(ASduType.C_BO_NA_1);
-        thenClientReceivesBitstringCommandConfirmation(ASduType.C_BO_NA_1);
-    }
-
-    // Temporarily disabled due to frame send retry failure - needs investigation
-    // @Test
-    public void testBitstringCommandWithTimeTag() throws Exception {
-        givenClientAndServerAreConnected();
-        
-        whenClientSendsBitstringCommandWithTimeTag();
-        
-        thenServerReceivesCommand(ASduType.C_BO_TA_1);
-        thenClientReceivesBitstringCommandConfirmation(ASduType.C_BO_TA_1);
-    }
-
-    private void givenClientAndServerAreConnected() throws IOException {
-        // Create connections directly instead of using builders, so we don't need to open a serial ports in tests
-        clientToServerPipe = new PipedOutputStream();
-        serverInput = new PipedInputStream();
-        serverInput.connect(clientToServerPipe);
-        
-        serverToClientPipe = new PipedOutputStream();
-        clientInput = new PipedInputStream();
-        clientInput.connect(serverToClientPipe);
-
-        spyServerEventListener = new RespondingServer();
-        server = new Iec101ServerConnection(
-            new DataInputStream(serverInput),
-            new DataOutputStream(serverToClientPipe),
-            new IEC60870Settings(),
-            LINK_ADDRESS
-        );
-
-        spyServerEventListener.setServerConnection(server);
-        server.startDataTransfer((IEC60870EventListener) spyServerEventListener);
-
-        spyClientListener = new AsduRecordingClient();
-        Iec101ClientSettings clientSettings = new Iec101ClientSettings();
-        clientSettings.setInitializationTimeoutMs(30000);  // Use 30 seconds for more reliability
-        
-        client = new Iec101ClientConnection(
-            new DataInputStream(clientInput),
-            new DataOutputStream(clientToServerPipe),
-            new IEC60870Settings(),
-            LINK_ADDRESS,
-            clientSettings
-        );
-        client.startDataTransfer((IEC60870EventListener) spyClientListener);
-
-        await().atMost(CONNECTION_TIMEOUT_SECONDS, TIMEOUT_UNIT)
-            .until(() -> spyServerEventListener.isConnectionReady() && spyClientListener.isConnectionReady());
+        thenClientReceivesConfirmation(ASduType.C_SE_NC_1, CauseOfTransmission.ACTIVATION_CON);
     }
 
     private void whenClientSendsInterrogationCommand() throws IOException {
         client.interrogation(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, new IeQualifierOfInterrogation(20));
     }
+    
 
     private void whenClientSendsSingleCommand(boolean state) throws IOException {
         client.singleCommand(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION,
@@ -399,9 +188,6 @@ public class Iec101ClientServerIntegrationTest extends Iec101IntegrationTest {
                            DOUBLE_COMMAND_ADDRESS, new IeDoubleCommand(state, 0, false));
     }
 
-    private void whenClientSendsTestCommand() throws IOException {
-        client.testCommand(COMMON_ADDRESS);
-    }
 
     private void whenClientSendsClockSynchronization() throws IOException {
         client.synchronizeClocks(COMMON_ADDRESS, new IeTime56(System.currentTimeMillis()));
@@ -434,493 +220,6 @@ public class Iec101ClientServerIntegrationTest extends Iec101IntegrationTest {
                                   new IeQualifierOfSetPointCommand(0, false));
     }
 
-    private void whenClientSendsRegulatingStepCommand(IeRegulatingStepCommand.StepCommandState state) throws IOException {
-        client.regulatingStepCommand(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                   REGULATING_STEP_ADDRESS, new IeRegulatingStepCommand(state, 0, false));
-    }
-
-    private void whenClientSendsParameterActivation() throws IOException {
-        client.parameterActivation(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                 PARAMETER_ACTIVATION_ADDRESS, 1);
-    }
-
-
-    private void whenClientSendsSingleCommandWithTimeTag(boolean state) throws IOException {
-        client.singleCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                      TIMETAG_SINGLE_COMMAND_ADDRESS,
-                                      new IeSingleCommand(state, 0, false), 
-                                      new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsTestCommandWithTimeTag() throws IOException {
-        client.testCommandWithTimeTag(COMMON_ADDRESS, 
-                                    new IeTestSequenceCounter(TEST_SEQUENCE_VALUE), 
-                                    new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsDoubleCommandWithTimeTag(IeDoubleCommand.DoubleCommandState state) throws IOException {
-        client.doubleCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                      TIMETAG_DOUBLE_COMMAND_ADDRESS,
-                                      new IeDoubleCommand(state, 0, false), 
-                                      new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsRegulatingStepCommandWithTimeTag(IeRegulatingStepCommand.StepCommandState state) throws IOException {
-        client.regulatingStepCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                               TIMETAG_REGULATING_STEP_ADDRESS,
-                                               new IeRegulatingStepCommand(state, 0, false), 
-                                               new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsSetNormalizedValueCommandWithTimeTag(float value) throws IOException {
-        client.setNormalizedValueCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                                   TIMETAG_NORMALIZED_SETPOINT_ADDRESS,
-                                                   new IeNormalizedValue(value), 
-                                                   new IeQualifierOfSetPointCommand(0, false),
-                                                   new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsSetScaledValueCommandWithTimeTag(int value) throws IOException {
-        client.setScaledValueCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                               TIMETAG_SCALED_SETPOINT_ADDRESS,
-                                               new IeScaledValue(value), 
-                                               new IeQualifierOfSetPointCommand(0, false),
-                                               new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsSetShortFloatCommandWithTimeTag(float value) throws IOException {
-        client.setShortFloatCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                              TIMETAG_FLOAT_SETPOINT_ADDRESS,
-                                              new IeShortFloat(value), 
-                                              new IeQualifierOfSetPointCommand(0, false),
-                                              new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void whenClientSendsParameterNormalizedValue(float value) throws IOException {
-        client.parameterMeasuredValueNormalized(COMMON_ADDRESS, PARAMETER_NORMALIZED_ADDRESS,
-                                               new IeNormalizedValue(value),
-                                               new IeQualifierOfParameterOfMeasuredValues(1, false, false));
-    }
-
-    private void whenClientSendsParameterScaledValue(int value) throws IOException {
-        client.parameterMeasuredValueScaled(COMMON_ADDRESS, PARAMETER_SCALED_ADDRESS,
-                                           new IeScaledValue(value),
-                                           new IeQualifierOfParameterOfMeasuredValues(1, false, false));
-    }
-
-    private void whenClientSendsParameterShortFloat(float value) throws IOException {
-        client.parameterMeasuredValueShortFloat(COMMON_ADDRESS, PARAMETER_FLOAT_ADDRESS,
-                                               new IeShortFloat(value),
-                                               new IeQualifierOfParameterOfMeasuredValues(1, false, false));
-    }
-
-    private void whenClientSendsBitstringCommand() throws IOException {
-        client.bitstringCommand(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                              BITSTRING_COMMAND_ADDRESS, new IeBinaryStateInformation(BITSTRING_VALUE_1));
-    }
-
-    private void whenClientSendsBitstringCommandWithTimeTag() throws IOException {
-        client.bitstringCommandWithTimeTag(COMMON_ADDRESS, CauseOfTransmission.ACTIVATION, 
-                                          TIMETAG_BITSTRING_COMMAND_ADDRESS, 
-                                          new IeBinaryStateInformation(BITSTRING_VALUE_1),
-                                          new IeTime56(System.currentTimeMillis()));
-    }
-
-    private void thenServerReceivesCommand(ASduType expectedAsduType) {
-        waitForServerToReceive(expectedAsduType);
-        assertTrue("Server should receive " + expectedAsduType, spyServerEventListener.hasReceived(expectedAsduType));
-    }
-
-    private void thenClientReceivesInterrogationResponse() {
-        waitForClientResponse(ASduType.M_ME_NB_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.M_ME_NB_1);
-        assertEquals("Should be scaled measurement response", ASduType.M_ME_NB_1, asdu.getTypeIdentification());
-        assertEquals("Should have spontaneous cause", CauseOfTransmission.SPONTANEOUS, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateInterrogationMeasurementResponse(asdu);
-    }
-
-    private void thenClientReceivesCounterInterrogationResponse() {
-        waitForClientResponse(ASduType.M_IT_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.M_IT_NA_1);
-        assertEquals("Should be counter response", ASduType.M_IT_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have interrogated by station cause", CauseOfTransmission.INTERROGATED_BY_STATION, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateCounterInterrogationResponse(asdu);
-    }
-
-    private void thenClientReceivesSingleCommandConfirmation() {
-        waitForClientResponse(ASduType.C_SC_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_SC_NA_1);
-        assertEquals("Should be single command confirmation", ASduType.C_SC_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateSingleCommandConfirmation(asdu);
-    }
-
-    private void thenClientReceivesDoubleCommandConfirmation() {
-        waitForClientResponse(ASduType.C_DC_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_DC_NA_1);
-        assertEquals("Should be double command confirmation", ASduType.C_DC_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateDoubleCommandConfirmation(asdu);
-    }
-
-    private void thenClientReceivesReadCommandResponse() {
-        waitForClientResponse(ASduType.M_ME_NB_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.M_ME_NB_1);
-        assertEquals("Should be measurement response", ASduType.M_ME_NB_1, asdu.getTypeIdentification());
-        assertEquals("Should have request cause", CauseOfTransmission.REQUEST, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateReadCommandMeasurementResponse(asdu);
-    }
-
-    private void thenClientReceivesClockSyncConfirmation() {
-        waitForClientResponse(ASduType.C_CS_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_CS_NA_1);
-        assertEquals("Should be clock sync confirmation", ASduType.C_CS_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateClockSyncConfirmation(asdu);
-    }
-
-    private void thenClientReceivesTestCommandConfirmation() {
-        waitForClientResponse(ASduType.C_TS_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_TS_NA_1);
-        assertEquals("Should be test command confirmation", ASduType.C_TS_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateTestCommandConfirmation(asdu);
-    }
-
-    private void thenClientReceivesSetPointConfirmation() {
-        waitForClientResponse(ASduType.C_SE_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_SE_NA_1);
-        assertEquals("Should be set point confirmation", ASduType.C_SE_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateSetPointConfirmation(asdu);
-    }
-
-    private void thenClientReceivesScaledSetPointConfirmation() {
-        waitForClientResponse(ASduType.C_SE_NB_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_SE_NB_1);
-        assertEquals("Should be scaled set point confirmation", ASduType.C_SE_NB_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateScaledSetPointConfirmation(asdu);
-    }
-
-    private void thenClientReceivesShortFloatSetPointConfirmation() {
-        waitForClientResponse(ASduType.C_SE_NC_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_SE_NC_1);
-        assertEquals("Should be short float set point confirmation", ASduType.C_SE_NC_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateShortFloatSetPointConfirmation(asdu);
-    }
-
-    private void thenClientReceivesRegulatingStepConfirmation() {
-        waitForClientResponse(ASduType.C_RC_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.C_RC_NA_1);
-        assertEquals("Should be regulating step confirmation", ASduType.C_RC_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateRegulatingStepConfirmation(asdu);
-    }
-
-    private void thenClientReceivesParameterActivationConfirmation() {
-        waitForClientResponse(ASduType.P_AC_NA_1);
-        
-        ASdu asdu = getLastReceivedAsdu(ASduType.P_AC_NA_1);
-        assertEquals("Should be parameter activation confirmation", ASduType.P_AC_NA_1, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateParameterActivationConfirmation(asdu);
-    }
-
-    private void thenClientReceivesTimeTaggedCommandConfirmation(ASduType expectedType) {
-        waitForClientResponse(expectedType);
-        
-        ASdu asdu = getLastReceivedAsdu(expectedType);
-        assertEquals("Should be time tagged command confirmation", expectedType, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateTimeTaggedCommandConfirmation(asdu);
-    }
-
-    private void thenClientReceivesParameterConfirmation(ASduType expectedType) {
-        waitForClientResponse(expectedType);
-        
-        ASdu asdu = getLastReceivedAsdu(expectedType);
-        assertEquals("Should be parameter confirmation", expectedType, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateParameterConfirmation(asdu);
-    }
-
-    private void thenClientReceivesBitstringCommandConfirmation(ASduType expectedType) {
-        waitForClientResponse(expectedType);
-        
-        ASdu asdu = getLastReceivedAsdu(expectedType);
-        assertEquals("Should be bitstring command confirmation", expectedType, asdu.getTypeIdentification());
-        assertEquals("Should have activation confirmation cause", CauseOfTransmission.ACTIVATION_CON, asdu.getCauseOfTransmission());
-        
-        validateCommonAsduProperties(asdu);
-        validateBitstringCommandConfirmation(asdu);
-    }
-    
-    private void validateCommonAsduProperties(ASdu asdu) {
-        assertEquals("Should have correct common address", COMMON_ADDRESS, asdu.getCommonAddress());
-        assertFalse("Should not be a test ASDU", asdu.isTestFrame());
-        assertNotNull("Should have information objects", asdu.getInformationObjects());
-        assertTrue("Should have at least one information object", asdu.getInformationObjects().length > 0);
-    }
-    
-    private void validateInterrogationMeasurementResponse(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have measurement address", MEASUREMENT_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have measurement values", elements.length > 0);
-        
-        assertTrue("Interrogation response should have scaled value", elements[0][0] instanceof IeScaledValue);
-        IeScaledValue scaledValue = (IeScaledValue) elements[0][0];
-        assertEquals("Interrogation response should return expected scaled value", SCALED_VALUE, scaledValue.getUnnormalizedValue());
-        
-        assertTrue("Second element should be quality", elements[0][1] instanceof IeQuality);
-        IeQuality quality = (IeQuality) elements[0][1];
-        assertFalse("Quality should indicate valid data", quality.isInvalid());
-        assertFalse("Quality should not be blocked", quality.isBlocked());
-        assertFalse("Quality should not be substituted", quality.isSubstituted());
-        assertFalse("Quality should not be not topical", quality.isNotTopical());
-        assertFalse("Quality should not have overflow", quality.isOverflow());
-    }
-
-    private void validateReadCommandMeasurementResponse(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have read command address", READ_COMMAND_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have measurement values", elements.length > 0);
-        
-        assertTrue("Read response should have normalized value", elements[0][0] instanceof IeNormalizedValue);
-        IeNormalizedValue normalizedValue = (IeNormalizedValue) elements[0][0];
-        assertEquals("Read response should return expected normalized value", 0.85, normalizedValue.getNormalizedValue(), NORMALIZED_TOLERANCE);
-        
-        assertTrue("Second element should be quality", elements[0][1] instanceof IeQuality);
-        IeQuality quality = (IeQuality) elements[0][1];
-        assertFalse("Quality should indicate valid data", quality.isInvalid());
-        assertFalse("Quality should not be blocked", quality.isBlocked());
-        assertFalse("Quality should not be substituted", quality.isSubstituted());
-        assertFalse("Quality should not be not topical", quality.isNotTopical());
-        assertFalse("Quality should not have overflow", quality.isOverflow());
-    }
-    
-    private void validateCounterInterrogationResponse(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have counter address", COUNTER_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have counter values", elements.length >= 2);
-        
-        // Validate first counter value
-        assertTrue("First element should be counter reading", elements[0][0] instanceof IeBinaryCounterReading);
-        IeBinaryCounterReading counter1 = (IeBinaryCounterReading) elements[0][0];
-        assertEquals("First counter should have expected value", COUNTER_VALUE_1, counter1.getCounterReading());
-        assertEquals("First counter should have sequence number 1", 1, counter1.getSequenceNumber());
-        
-        // Validate second counter value
-        assertTrue("Second counter element should be counter reading", elements[1][0] instanceof IeBinaryCounterReading);
-        IeBinaryCounterReading counter2 = (IeBinaryCounterReading) elements[1][0];
-        assertEquals("Second counter should have expected value", COUNTER_VALUE_2, counter2.getCounterReading());
-        assertEquals("Second counter should have sequence number 2", 2, counter2.getSequenceNumber());
-    }
-    
-    private void validateSingleCommandConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have expected single command address", SINGLE_COMMAND_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have single command element", elements[0][0] instanceof IeSingleCommand);
-        
-        IeSingleCommand command = (IeSingleCommand) elements[0][0];
-        assertTrue("Single command should be set to true (ON)", command.isCommandStateOn());
-        assertEquals("Single command should have no qualifier", 0, command.getQualifier());
-        assertFalse("Single command should not be select", command.isSelect());
-    }
-    
-    private void validateDoubleCommandConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have expected double command address", DOUBLE_COMMAND_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have double command element", elements[0][0] instanceof IeDoubleCommand);
-        
-        IeDoubleCommand command = (IeDoubleCommand) elements[0][0];
-        assertEquals("Double command should be set to ON", IeDoubleCommand.DoubleCommandState.ON, command.getCommandState());
-        assertEquals("Double command should have no qualifier", 0, command.getQualifier());
-        assertFalse("Double command should not be select", command.isSelect());
-    }
-    
-    private void validateSetPointConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Should have expected set point address", SET_POINT_ADDRESS, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have normalized value element", elements[0][0] instanceof IeNormalizedValue);
-        assertTrue("Should have qualifier element", elements[0][1] instanceof IeQualifierOfSetPointCommand);
-        
-        IeNormalizedValue setValue = (IeNormalizedValue) elements[0][0];
-        assertEquals("Set point should have expected normalized value", 0.75, setValue.getNormalizedValue(), NORMALIZED_TOLERANCE);
-        
-        IeQualifierOfSetPointCommand qualifier = (IeQualifierOfSetPointCommand) elements[0][1];
-        assertEquals("Set point qualifier should be zero", 0, qualifier.getQl());
-        assertFalse("Set point should not be select", qualifier.isSelect());
-    }
-    
-    private void validateClockSyncConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertEquals("Clock sync should use address 0", 0, objects[0].getInformationObjectAddress());
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have time element", elements[0][0] instanceof IeTime56);
-        
-        IeTime56 timeElement = (IeTime56) elements[0][0];
-        long currentTime = System.currentTimeMillis();
-        long receivedTime = timeElement.getTimestamp();
-        
-        long timeDiff = Math.abs(currentTime - receivedTime);
-        assertTrue("Clock sync time should be within tolerance of current time (diff: " + timeDiff + "ms)", 
-                   timeDiff < TIME_TOLERANCE_MS);
-    }
-    
-    private void validateTestCommandConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid test command address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have test command elements", elements.length > 0);
-        
-        assertTrue("Should have test pattern", elements[0][0] instanceof IeFixedTestBitPattern);
-    }
-
-    private void validateScaledSetPointConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid scaled set point address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have scaled set point elements", elements.length > 0);
-        
-        assertTrue("Should have scaled value", elements[0][0] instanceof IeScaledValue);
-        IeScaledValue scaledValue = (IeScaledValue) elements[0][0];
-        assertTrue("Scaled value should be valid", scaledValue.getUnnormalizedValue() != 0);
-    }
-
-    private void validateShortFloatSetPointConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid short float set point address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have short float set point elements", elements.length > 0);
-        
-        assertTrue("Should have short float value", elements[0][0] instanceof IeShortFloat);
-        IeShortFloat shortFloat = (IeShortFloat) elements[0][0];
-        assertTrue("Short float value should be valid", shortFloat.getValue() != 0.0f);
-    }
-
-    private void validateRegulatingStepConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid regulating step address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have regulating step elements", elements.length > 0);
-        
-        assertTrue("Should have regulating step command", elements[0][0] instanceof IeRegulatingStepCommand);
-    }
-
-    private void validateParameterActivationConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid parameter activation address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have parameter activation elements", elements.length > 0);
-        
-        assertTrue("Should have parameter qualifier", elements[0][0] instanceof IeQualifierOfParameterActivation);
-    }
-
-    private void validateTimeTaggedCommandConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid time tagged command address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have time tagged command elements", elements.length > 0);
-        
-        boolean hasTimeElement = false;
-        for (InformationElement element : elements[0]) {
-            if (element instanceof IeTime56) {
-                hasTimeElement = true;
-                break;
-            }
-        }
-        assertTrue("Should have time element", hasTimeElement);
-    }
-
-    private void validateParameterConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid parameter address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have parameter elements", elements.length > 0);
-        
-        // Parameter confirmations should have at least one parameter element
-        InformationElement firstElement = elements[0][0];
-        assertTrue("Should have parameter element", 
-                   firstElement instanceof IeNormalizedValue ||
-                   firstElement instanceof IeScaledValue ||
-                   firstElement instanceof IeShortFloat);
-    }
-
-    private void validateBitstringCommandConfirmation(ASdu asdu) {
-        InformationObject[] objects = asdu.getInformationObjects();
-        assertTrue("Should have valid bitstring command address", objects[0].getInformationObjectAddress() >= 0);
-        
-        InformationElement[][] elements = objects[0].getInformationElements();
-        assertTrue("Should have bitstring command elements", elements.length > 0);
-        
-        assertTrue("Should have bitstring element", elements[0][0] instanceof IeBinaryStateInformation);
-    }
-
-    private ASdu getLastReceivedAsdu(ASduType type) {
-        return spyClientListener.getLastReceivedAsduOfType(type);
-    }
-
     @Override
     public void tearDown() {
         super.tearDown();
@@ -949,5 +248,103 @@ public class Iec101ClientServerIntegrationTest extends Iec101IntegrationTest {
                 clientInput = null;
             }
         } catch (IOException e) { /* ignore */ }
+    }
+
+    private void givenClientAndIec101ServerAreConnectedWithFastPolling() throws IOException {
+        // Create connections directly instead of using builders, so we don't need to open serial ports in tests
+        clientToServerPipe = new PipedOutputStream();
+        serverInput = new PipedInputStream();
+        serverInput.connect(clientToServerPipe);
+        
+        serverToClientPipe = new PipedOutputStream();
+        clientInput = new PipedInputStream();
+        clientInput.connect(serverToClientPipe);
+
+        spyIec101ServerEventListener = new Iec101RespondingServer();
+        server = new Iec101ServerConnection(
+            new DataInputStream(serverInput),
+            new DataOutputStream(serverToClientPipe),
+            new IEC60870Settings(),
+            LINK_ADDRESS
+        );
+
+        spyIec101ServerEventListener.setServerConnection(server);
+        server.startDataTransfer(spyIec101ServerEventListener);
+
+        asduRecordingClient = new AsduRecordingClient();
+        spyClientListener = asduRecordingClient;
+        Iec101ClientSettings clientSettings = new Iec101ClientSettings();
+        clientSettings.setPollingIntervalMs(200);
+        
+        client = new Iec101ClientConnection(
+            new DataInputStream(clientInput),
+            new DataOutputStream(clientToServerPipe),
+            new IEC60870Settings(),
+            LINK_ADDRESS,
+            clientSettings
+        );
+        client.startDataTransfer(asduRecordingClient);
+
+        await().atMost(CONNECTION_TIMEOUT_SECONDS, TIMEOUT_UNIT)
+            .until(() -> spyIec101ServerEventListener.isConnectionReady() && spyClientListener.isConnectionReady());
+    }
+    
+    private void thenIec101ServerReceivesCommand(ASduType expectedType) {
+        await().atMost(CONNECTION_TIMEOUT_SECONDS, TIMEOUT_UNIT)
+            .until(() -> spyIec101ServerEventListener.getReceivedAsdus().contains(expectedType));
+        
+        assertTrue("Server should receive " + expectedType, 
+                  spyIec101ServerEventListener.getReceivedAsdus().contains(expectedType));
+    }
+
+    private ASdu awaitAndAssertAsdu(ASduType type, CauseOfTransmission cot, String description) {
+        await().atMost(CONNECTION_TIMEOUT_SECONDS, TIMEOUT_UNIT)
+            .until(() -> asduRecordingClient.hasReceived(type, cot));
+        
+        ASdu asdu = asduRecordingClient.findAsdu(type, cot).orElse(null);
+        assertNotNull(description + " should be received", asdu);
+        return asdu;
+    }
+
+    private ASdu awaitAndAssertAsduWithContent(ASduType type, CauseOfTransmission cot, String description) {
+        ASdu asdu = awaitAndAssertAsdu(type, cot, description);
+        
+        InformationObject[] infoObjects = asdu.getInformationObjects();
+        assertNotNull(description + " should have information objects", infoObjects);
+        assertTrue(description + " should have at least one information object", infoObjects.length > 0);
+        
+        return asdu;
+    }
+    
+    private void thenClientReceivesConfirmation(ASduType expectedType, CauseOfTransmission expectedCot) {
+        awaitAndAssertAsdu(expectedType, expectedCot, expectedType + " confirmation");
+    }
+    
+    private void thenClientReceivesTermination(ASduType expectedType, CauseOfTransmission expectedCot) {
+        awaitAndAssertAsdu(expectedType, expectedCot, expectedType + " termination");
+    }
+    
+    private void thenClientReceivesSinglePointData() {
+        awaitAndAssertAsduWithContent(ASduType.M_SP_NA_1, CauseOfTransmission.INTERROGATED_BY_STATION, "single point data");
+    }
+    
+    private void thenClientReceivesDoublePointData() {
+        awaitAndAssertAsduWithContent(ASduType.M_DP_NA_1, CauseOfTransmission.INTERROGATED_BY_STATION, "double point data");
+    }
+    
+    private void thenClientReceivesMeasurementData() {
+        awaitAndAssertAsduWithContent(ASduType.M_ME_NB_1, CauseOfTransmission.INTERROGATED_BY_STATION, "measurement data");
+    }
+    
+    private void thenClientReceivesCounterData() {
+        awaitAndAssertAsduWithContent(ASduType.M_IT_NA_1, CauseOfTransmission.INTERROGATED_BY_STATION, "counter data");
+    }
+    
+    private void thenClientReceivesClockSyncResponse() {
+        awaitAndAssertAsduWithContent(ASduType.C_CS_NA_1, CauseOfTransmission.ACTIVATION_CON, "clock sync response");
+    }
+    
+    private void thenClientReceivesReadResponse() {
+        awaitAndAssertAsduWithContent(ASduType.M_ME_NA_1, CauseOfTransmission.REQUEST, "read response");
     }
 }

--- a/src/test/java/net/sympower/iec60870/spy/AsduRecordingClient.java
+++ b/src/test/java/net/sympower/iec60870/spy/AsduRecordingClient.java
@@ -1,12 +1,16 @@
 package net.sympower.iec60870.spy;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
-import net.sympower.iec60870.common.api.IEC60870EventListener;
 import net.sympower.iec60870.common.ASdu;
 import net.sympower.iec60870.common.ASduType;
+import net.sympower.iec60870.common.CauseOfTransmission;
+import net.sympower.iec60870.common.api.IEC60870EventListener;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class AsduRecordingClient implements IEC60870EventListener, ClientSpy {
   private volatile boolean connectionReady = false;
@@ -56,5 +60,24 @@ public class AsduRecordingClient implements IEC60870EventListener, ClientSpy {
         .filter(asdu -> asdu.getTypeIdentification() == type)
         .reduce((first, second) -> second)
         .orElse(null);
+  }
+
+  public boolean hasReceived(ASduType type, CauseOfTransmission cot) {
+    return receivedAsdus.stream()
+        .anyMatch(asdu -> asdu.getTypeIdentification() == type && 
+                         asdu.getCauseOfTransmission() == cot);
+  }
+
+  public Optional<ASdu> findAsdu(ASduType type, CauseOfTransmission cot) {
+    return receivedAsdus.stream()
+        .filter(asdu -> asdu.getTypeIdentification() == type && 
+                       asdu.getCauseOfTransmission() == cot)
+        .findFirst();
+  }
+
+  public List<ASdu> findAsdusOfType(ASduType type) {
+    return receivedAsdus.stream()
+        .filter(asdu -> asdu.getTypeIdentification() == type)
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/net/sympower/iec60870/spy/Iec101RespondingServer.java
+++ b/src/test/java/net/sympower/iec60870/spy/Iec101RespondingServer.java
@@ -1,0 +1,247 @@
+/*
+ * Original work: Copyright 2014-20 Fraunhofer ISE (OpenMUC j60870)
+ *
+ * Modified work: Copyright 2025 Sympower
+ *
+ * This file is part of the enhanced IEC 60870 library.
+ * Original project: https://github.com/openmuc/j60870
+ * Enhanced version: https://github.com/josh-mills-sympower/IEC-60870-5
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package net.sympower.iec60870.spy;
+
+import net.sympower.iec60870.common.ASdu;
+import net.sympower.iec60870.common.ASduType;
+import net.sympower.iec60870.common.CauseOfTransmission;
+import net.sympower.iec60870.common.IEC60870Protocol;
+import net.sympower.iec60870.common.api.IEC60870Connection;
+import net.sympower.iec60870.common.api.IEC60870EventListener;
+import net.sympower.iec60870.common.api.IEC60870ServerListener;
+import net.sympower.iec60870.common.elements.*;
+import net.sympower.iec60870.iec101.connection.Iec101ServerConnection;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+
+public class Iec101RespondingServer implements IEC60870EventListener, ServerSpy {
+
+    private static final int COMMON_ADDRESS = 1;
+    private static final int MEASUREMENT_ADDRESS = 100;
+    private static final int COUNTER_ADDRESS = 200;
+    private static final int READ_COMMAND_ADDRESS = 7000;
+    private static final int SINGLE_POINT_ADDRESS = 300;
+    private static final int DOUBLE_POINT_ADDRESS = 400;
+    
+    // Test values
+    private static final int SCALED_VALUE = 1234;
+    private static final short NORMALIZED_VALUE = 5678;
+    private static final int COUNTER_VALUE = 999;
+
+    private Iec101ServerConnection serverConnection;
+    private final ConcurrentLinkedQueue<ASduType> receivedAsdus = new ConcurrentLinkedQueue<>();
+    private final AtomicInteger receivedCommandCount = new AtomicInteger(0);
+    private volatile boolean connectionReady = false;
+    private volatile boolean connectionLost = false;
+
+    public void onConnectionAccepted(IEC60870Connection connection) {
+        this.serverConnection = (Iec101ServerConnection) connection;
+    }
+
+    @Override
+    public void onConnectionReady() {
+        this.connectionReady = true;
+        this.connectionLost = false;
+    }
+
+    @Override
+    public void onAsduReceived(ASdu asdu) {
+        ASduType type = asdu.getTypeIdentification();
+        receivedAsdus.add(type);
+
+        try {
+            switch (type) {
+                case C_IC_NA_1:  // Interrogation
+                    handleInterrogation(asdu);
+                    break;
+                case C_CI_NA_1:  // Counter interrogation
+                    handleCounterInterrogation(asdu);
+                    break;
+                case C_CS_NA_1:  // Clock sync
+                    handleClockSync(asdu);
+                    break;
+                case C_RD_NA_1:  // Read command
+                    handleReadCommand(asdu);
+                    break;
+                default:
+                    // All other commands just get confirmation
+                    if (isCommand(type)) {
+                        receivedCommandCount.incrementAndGet();
+                        serverConnection.queueClass1Response(
+                            IEC60870Protocol.createConfirmation(asdu, asdu.getOriginatorAddress())
+                        );
+                    }
+            }
+        } catch (Exception e) {
+            fail("Error handling ASDU in server: " + e.getMessage());
+        }
+    }
+
+    private void handleInterrogation(ASdu asdu) {
+        // Queue confirmation as Class 1 (high priority)
+        serverConnection.queueClass1Response(
+            IEC60870Protocol.createConfirmation(asdu, asdu.getOriginatorAddress())
+        );
+        
+        // Send single point information
+        InformationObject[] singlePoints = new InformationObject[] {
+            new InformationObject(SINGLE_POINT_ADDRESS, new InformationElement[][] {
+                { new IeSinglePointWithQuality(true, false, false, false, false) },
+                { new IeSinglePointWithQuality(false, false, false, false, false) }
+            })
+        };
+        serverConnection.queueClass2Response(new ASdu(
+            ASduType.M_SP_NA_1, true, CauseOfTransmission.INTERROGATED_BY_STATION,
+            false, false, 0, asdu.getCommonAddress(), singlePoints
+        ));
+        
+        // Send double point information
+        InformationObject[] doublePoints = new InformationObject[] {
+            new InformationObject(DOUBLE_POINT_ADDRESS, new InformationElement[][] {
+                { new IeDoublePointWithQuality(IeDoublePointWithQuality.DoublePointInformation.ON, false, false, false, false) }
+            })
+        };
+        serverConnection.queueClass2Response(new ASdu(
+            ASduType.M_DP_NA_1, true, CauseOfTransmission.INTERROGATED_BY_STATION,
+            false, false, 0, asdu.getCommonAddress(), doublePoints
+        ));
+        
+        // Send measurements as Class 2 (low priority)
+        InformationObject[] measurements = new InformationObject[] {
+            new InformationObject(MEASUREMENT_ADDRESS, new InformationElement[][] {
+                { new IeScaledValue(SCALED_VALUE), new IeQuality(false, false, false, false, false) },
+                { new IeScaledValue(-5432), new IeQuality(false, false, false, false, false) },
+                { new IeScaledValue(10000), new IeQuality(false, false, false, false, false) }
+            })
+        };
+        serverConnection.queueClass2Response(new ASdu(
+            ASduType.M_ME_NB_1, true, CauseOfTransmission.INTERROGATED_BY_STATION,
+            false, false, 0, asdu.getCommonAddress(), measurements
+        ));
+        
+        // Queue termination as Class 1 (high priority)
+        serverConnection.queueClass1Response(
+            IEC60870Protocol.createTermination(asdu, asdu.getOriginatorAddress())
+        );
+    }
+
+    private void handleCounterInterrogation(ASdu asdu) {
+        // Queue confirmation
+        serverConnection.queueClass1Response(
+            IEC60870Protocol.createConfirmation(asdu, asdu.getOriginatorAddress())
+        );
+        
+        // Send counter values
+        InformationObject[] counters = new InformationObject[] {
+            new InformationObject(COUNTER_ADDRESS, new InformationElement[][] {
+                { new IeBinaryCounterReading(COUNTER_VALUE, 0) }
+            })
+        };
+        serverConnection.queueClass2Response(new ASdu(
+            ASduType.M_IT_NA_1, true, CauseOfTransmission.INTERROGATED_BY_STATION,
+            false, false, 0, asdu.getCommonAddress(), counters
+        ));
+        
+        // Queue termination
+        serverConnection.queueClass1Response(
+            IEC60870Protocol.createTermination(asdu, asdu.getOriginatorAddress())
+        );
+    }
+
+    private void handleClockSync(ASdu asdu) {
+        InformationObject io = asdu.getInformationObjects()[0];
+        IeTime56 time = (IeTime56) io.getInformationElements()[0][0];
+        
+        serverConnection.queueClass1Response(new ASdu(
+            ASduType.C_CS_NA_1, false, CauseOfTransmission.ACTIVATION_CON,
+            false, false, asdu.getOriginatorAddress(), asdu.getCommonAddress(),
+            new InformationObject(0, time)
+        ));
+    }
+
+    private void handleReadCommand(ASdu asdu) {
+        InformationObject io = asdu.getInformationObjects()[0];
+        int address = io.getInformationObjectAddress();
+        
+        if (address == READ_COMMAND_ADDRESS) {
+            InformationObject responseObj = new InformationObject(address, new InformationElement[][] {
+                { new IeNormalizedValue(NORMALIZED_VALUE), new IeQuality(false, false, false, false, false) }
+            });
+            
+            serverConnection.queueClass1Response(new ASdu(
+                ASduType.M_ME_NA_1, false, CauseOfTransmission.REQUEST,
+                false, false, 0, asdu.getCommonAddress(), responseObj
+            ));
+        }
+    }
+
+    @Override
+    public void onConnectionLost(IOException cause) {
+        this.connectionLost = true;
+        this.connectionReady = false;
+    }
+
+    public void setServerConnection(IEC60870Connection connection) {
+        this.serverConnection = (Iec101ServerConnection) connection;
+    }
+
+    private boolean isCommand(ASduType type) {
+        return type.getId() >= 45 && type.getId() <= 113; // Command range
+    }
+
+    public boolean isConnectionReady() {
+        return connectionReady;
+    }
+
+    public boolean isConnectionLost() {
+        return connectionLost;
+    }
+
+    public ConcurrentLinkedQueue<ASduType> getReceivedAsdus() {
+        return receivedAsdus;
+    }
+
+    public int getReceivedCommandCount() {
+        return receivedCommandCount.get();
+    }
+
+    public ASduType getLastReceivedAsdu() {
+        return receivedAsdus.isEmpty() ? null : receivedAsdus.peek();
+    }
+    
+    @Override
+    public boolean hasReceived(ASduType type) {
+        return receivedAsdus.contains(type);
+    }
+    
+    @Override
+    public boolean hasReceivedAnyCommand() {
+        return receivedCommandCount.get() > 0;
+    }
+    
+}


### PR DESCRIPTION
- Apply configurable inter frame delay when sending frames.
- Refine some incorrect FunctionCode-s.
- Correctly respond to REQUEST_CLASS_1_DATA and REQUEST_CLASS_2_DATA on server side.
- Correctly poll server on client side.
- Correctly consider the linkAddress length when encoding and decoding frames.
- Correct README-s.